### PR TITLE
Improve line hit testing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1615,13 +1615,15 @@ function hitTestAnnotation(ix,iy){
   return -1;
 }
 function hitTestSegment(ix,iy){
-  let best=-1, bestD=6;
-  for(let i=0;i<segments.length;i++){
+  for(let i=segments.length-1;i>=0;i--){
     const s=segments[i];
-    const d = distPointToSegment(ix,iy, s.x1,s.y1,s.x2,s.y2);
-    if(d<bestD){ bestD=d; best=i; }
+    const L=layers[s.layer];
+    if(!L || !L.visible) continue;
+    const tol=Math.max((s.thick||1)/2,0.5);
+    const d=distPointToSegment(ix,iy,s.x1,s.y1,s.x2,s.y2);
+    if(d<=tol) return i;
   }
-  return best;
+  return -1;
 }
 function distPointToSegment(px,py,x1,y1,x2,y2){
   const vx=x2-x1, vy=y2-y1, wx=px-x1, wy=py-y1;

--- a/docs/js/tools.js
+++ b/docs/js/tools.js
@@ -12,6 +12,14 @@ function imgToScreen(ix, iy) {
     return [x, y];
 }
 
+// Offscreen context used for precise hit testing
+const hitCtx = (() => {
+    if (typeof OffscreenCanvas !== 'undefined') {
+        return new OffscreenCanvas(1, 1).getContext('2d');
+    }
+    return document.createElement('canvas').getContext('2d');
+})();
+
 // Snapping
 function snapPosition(ix, iy) {
     if (config.snapToGrid) {
@@ -47,19 +55,24 @@ function hitTestAnnotation(ix, iy) {
 }
 
 function hitTestSegment(ix, iy) {
-    // Return the first segment within a small distance of the point.
-    const tolerance = 5; // pixels in image space
-    for (let li = 0; li < layers.length; li++) {
+    // Use the canvas API to determine if the point lies within a stroked path
+    for (let li = layers.length - 1; li >= 0; li--) {
         const layer = layers[li];
         if (!layer.visible) continue;
-        for (let si = 0; si < layer.segments.length; si++) {
+        for (let si = layer.segments.length - 1; si >= 0; si--) {
             const seg = layer.segments[si];
-            for (let i = 0; i < seg.points.length - 1; i++) {
-                const p1 = seg.points[i];
-                const p2 = seg.points[i + 1];
-                if (pointToSegmentDistance(ix, iy, p1, p2) <= tolerance) {
-                    return { layer: li, index: si };
-                }
+            if (!seg || seg.points.length < 2) continue;
+            // Use the segment's actual thickness so hits only register on the line itself
+            hitCtx.lineWidth = layer.thickness / viewScale;
+            hitCtx.lineCap = 'round';
+            hitCtx.lineJoin = 'round';
+            hitCtx.beginPath();
+            hitCtx.moveTo(seg.points[0].x, seg.points[0].y);
+            for (let i = 1; i < seg.points.length; i++) {
+                hitCtx.lineTo(seg.points[i].x, seg.points[i].y);
+            }
+            if (hitCtx.isPointInStroke(ix, iy)) {
+                return { layer: li, index: si };
             }
         }
     }
@@ -76,7 +89,6 @@ function pointToSegmentDistance(px, py, p1, p2) {
     const clamped = Math.max(0, Math.min(1, t));
     const x = x1 + clamped * dx, y = y1 + clamped * dy;
     return Math.hypot(px - x, py - y);
- codex/fix-line-drawing-color-on-click-xt54x0
 }
 
 function pointsEqual(p1, p2, tol = 0.1) {
@@ -107,8 +119,6 @@ function collectConnectedSegments(layerIndex, startIndex) {
         }
     }
     return result;
-
-DevSchmeaticHtml
 }
 
 // Image analysis


### PR DESCRIPTION
## Summary
- ensure canvas hit testing uses actual stroke width without extra tolerance
- align inline hit test with layer visibility and segment thickness

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b1902965888325a955589ac83275df