### PR TITLE
Improve line hit testing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1615,25 +1615,32 @@ function hitTestAnnotation(ix,iy){
   return -1;
 }
 function hitTestSegment(ix,iy){
-  let best=-1, bestD=6;
-  for(let i=0;i<segments.length;i++){
+  for(let i=segments.length-1;i>=0;i--){
     const s=segments[i];
-    const d = distPointToSegment(ix,iy, s.x1,s.y1,s.x2,s.y2);
-    if(d<bestD){ bestD=d; best=i; }
+    const L=layers[s.layer];
+    if(!L || !L.visible) continue;
+    if(!s.path){
+      const path=new Path2D();
+      path.moveTo(s.x1,s.y1);
+      path.lineTo(s.x2,s.y2);
+      s.path=path;
+      s.bbox={
+        minX:Math.min(s.x1,s.x2),
+        maxX:Math.max(s.x1,s.x2),
+        minY:Math.min(s.y1,s.y2),
+        maxY:Math.max(s.y1,s.y2)
+      };
+    }
+    const half=(s.thick||L.thickness||1)/viewScale/2;
+    const {minX,maxX,minY,maxY}=s.bbox;
+    if(ix<minX-half||ix>maxX+half||iy<minY-half||iy>maxY+half) continue;
+    hitCtx.lineWidth=(s.thick||L.thickness||1)/viewScale;
+    hitCtx.lineCap='round';
+    hitCtx.lineJoin='round';
+    if(hitCtx.isPointInStroke(s.path,ix,iy)) return i;
   }
-  return best;
+  return -1;
 }
-function distPointToSegment(px,py,x1,y1,x2,y2){
-  const vx=x2-x1, vy=y2-y1, wx=px-x1, wy=py-y1;
-  const c1 = vx*wx + vy*wy;
-  if(c1<=0) return Math.hypot(px-x1,py-y1);
-  const c2 = vx*vx + vy*vy;
-  if(c2<=c1) return Math.hypot(px-x2,py-y2);
-  const b = c1 / c2;
-  const bx = x1 + b*vx, by = y1 + b*vy;
-  return Math.hypot(px-bx, py-by);
-}
-
 function eraseAt(ix,iy,size){ if(!layers.length) return; clearMask(layers[activeLayer].mask, Math.round(ix), Math.round(iy), Math.max(1, Math.round(size/2))); }
 function eraseLineTo(ix,iy,size){ if(!layers.length) return; if(!lastErase){ lastErase={x:ix,y:iy}; eraseAt(ix,iy,size); return; } const steps=Math.ceil(Math.hypot(ix-lastErase.x, iy-lastErase.y) / 1); for(let t=0;t<=steps;t++){ const x=lerp(lastErase.x,ix,t/steps); const y=lerp(lastErase.y,iy,t/steps); eraseAt(x,y,size); } lastErase={x:ix,y:iy}; }
 


### PR DESCRIPTION
## Summary
- cache Path2D geometry and bounding boxes for precise segment clicks
- apply the same stroke-aware hit test in legacy inline logic to avoid off-line highlights

## Testing
- `npm test` *(fails: package.json missing)*
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1902965888325a955589ac83275df