### PR TITLE
Improve line hit testing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1605,35 +1605,6 @@ consoleRun.addEventListener('click',()=> runCommand(consoleIn.value));
 consoleIn.addEventListener('keydown',(e)=>{ if(e.key==='Enter') runCommand(consoleIn.value); });
 clearHistoryBtn.addEventListener('click',()=>{ history=[]; historyList.innerHTML=''; logHistory('History cleared'); });
 
-function hitTestAnnotation(ix,iy){
-  for(let i=annotations.length-1;i>=0;i--){
-    const a=annotations[i]; const size=Math.max(10, +a.size||18);
-    const m=document.createElement('canvas').getContext('2d'); m.font=`${size}px system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, sans-serif`;
-    const w=Math.max(10, m.measureText(a.text||'').width); const h=Math.max(10, size*1.2);
-    if(ix>=a.x && ix<=a.x+w && iy>=a.y-h/2 && iy<=a.y+h/2) return i;
-  }
-  return -1;
-}
-function hitTestSegment(ix,iy){
-  let best=-1, bestD=6;
-  for(let i=0;i<segments.length;i++){
-    const s=segments[i];
-    const d = distPointToSegment(ix,iy, s.x1,s.y1,s.x2,s.y2);
-    if(d<bestD){ bestD=d; best=i; }
-  }
-  return best;
-}
-function distPointToSegment(px,py,x1,y1,x2,y2){
-  const vx=x2-x1, vy=y2-y1, wx=px-x1, wy=py-y1;
-  const c1 = vx*wx + vy*wy;
-  if(c1<=0) return Math.hypot(px-x1,py-y1);
-  const c2 = vx*vx + vy*vy;
-  if(c2<=c1) return Math.hypot(px-x2,py-y2);
-  const b = c1 / c2;
-  const bx = x1 + b*vx, by = y1 + b*vy;
-  return Math.hypot(px-bx, py-by);
-}
-
 function eraseAt(ix,iy,size){ if(!layers.length) return; clearMask(layers[activeLayer].mask, Math.round(ix), Math.round(iy), Math.max(1, Math.round(size/2))); }
 function eraseLineTo(ix,iy,size){ if(!layers.length) return; if(!lastErase){ lastErase={x:ix,y:iy}; eraseAt(ix,iy,size); return; } const steps=Math.ceil(Math.hypot(ix-lastErase.x, iy-lastErase.y) / 1); for(let t=0;t<=steps;t++){ const x=lerp(lastErase.x,ix,t/steps); const y=lerp(lastErase.y,iy,t/steps); eraseAt(x,y,size); } lastErase={x:ix,y:iy}; }
 

--- a/docs/js/canvas.js
+++ b/docs/js/canvas.js
@@ -71,17 +71,11 @@ function drawLayer(layer, ctx, layerIndex) {
             if (i === 0) ctx.moveTo(pt.x, pt.y);
             else ctx.lineTo(pt.x, pt.y);
         }
-codex/fix-line-drawing-color-on-click-xt54x0
-        // Highlight selected segments in cyan; otherwise use layer color
-        const isSelected = selectedSeg.some(s => s.layer === layerIndex && s.index === si);
+        // Highlight the selected segment in cyan; otherwise use the layer color
+        const isSelected = selectedSeg &&
+            selectedSeg.layer === layerIndex &&
+            selectedSeg.index === si;
         ctx.strokeStyle = isSelected ? 'cyan' : layer.color;
-        // Highlight selected segment in cyan; otherwise use layer color
-        if (selectedSeg && selectedSeg.layer === layerIndex && selectedSeg.index === si) {
-            ctx.strokeStyle = 'cyan';
-        } else {
-            ctx.strokeStyle = layer.color;
-        }
- DevSchmeaticHtml
         ctx.stroke();
     }
 }

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -109,12 +109,11 @@ function setupEventListeners() {
 
         let hit = hitTestSymbol(ix, iy);
         if (hit >= 0) {
- codex/fix-line-drawing-color-on-click-xt54x0
-            selectedSym = hit; selectedSeg = []; selectedAnn = -1;
-
-            selectedSym = hit; selectedSeg = null; selectedAnn = -1;
-DevSchmeaticHtml
-            draggingSym = true; suppressNextClick = true;
+            selectedSym = hit;
+            selectedSeg = null;
+            selectedAnn = -1;
+            draggingSym = true;
+            suppressNextClick = true;
             syncSymbolUI();
             redrawOverlay();
             return;
@@ -122,12 +121,12 @@ DevSchmeaticHtml
 
         hit = hitTestAnnotation(ix, iy);
         if (hit >= 0) {
-codex/fix-line-drawing-color-on-click-xt54x0
-            selectedAnn = hit; selectedSym = -1; selectedSeg = [];
-
-            selectedAnn = hit; selectedSym = -1; selectedSeg = null;
-DevSchmeaticHtml
-            draggingAnn = true; annOffset.dx = ix - annotations[hit].x; annOffset.dy = iy - annotations[hit].y;
+            selectedAnn = hit;
+            selectedSym = -1;
+            selectedSeg = null;
+            draggingAnn = true;
+            annOffset.dx = ix - annotations[hit].x;
+            annOffset.dy = iy - annotations[hit].y;
             suppressNextClick = true;
             redrawOverlay();
             return;
@@ -135,13 +134,9 @@ DevSchmeaticHtml
 
         hit = hitTestSegment(ix, iy);
         if (hit) {
- codex/fix-line-drawing-color-on-click-xt54x0
-            // Collect all connected segments to highlight entire path
-            selectedSeg = collectConnectedSegments(hit.layer, hit.index);
-            selectedSym = -1; selectedAnn = -1;
-
-            selectedSeg = hit; selectedSym = -1; selectedAnn = -1;
- DevSchmeaticHtml
+            selectedSeg = hit;
+            selectedSym = -1;
+            selectedAnn = -1;
             // Highlight segment without starting a drag operation
             suppressNextClick = true;
             redrawOverlay();

--- a/docs/js/state.js
+++ b/docs/js/state.js
@@ -20,17 +20,9 @@ let retypeMode = false;
 
 // Selections and dragging
 let selectedSym = -1;
- codex/fix-line-drawing-color-on-click-xt54x0
-// Track selected segments as an array of objects { layer, index }
-// rather than a single index so we can highlight entire connected paths.
-// An empty array means no segment is selected.
-let selectedSeg = [];
-
-// Track a selected segment as an object { layer, index }
-// rather than a simple index so we know which layer it belongs to.
+// Track a selected segment as an object { layer, index }.
 // null means no segment is selected.
 let selectedSeg = null;
-DevSchmeaticHtml
 let selectedAnn = -1;
 let draggingSym = false;
 let draggingSeg = false;


### PR DESCRIPTION
## Summary
- fix residual merge text that broke state initialization
- unify segment selection logic and highlight rendering
- remove redundant hit-test helpers from HTML to rely on shared tooling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1902965888325a955589ac83275df