### PR TITLE
Fix hit testing for line segments

### DIFF
--- a/docs/js/tools.js
+++ b/docs/js/tools.js
@@ -72,7 +72,6 @@ function ensureSegmentPath(seg) {
     seg.bbox = { minX, maxX, minY, maxY };
 }
 
- codex/find-better-mouse-click-detection-method-jn7jky
 function hitTestSegment(x, y) {
     // Accept either screen or image coordinates.
     // If the point appears to be in image space, convert it.
@@ -85,81 +84,23 @@ function hitTestSegment(x, y) {
 
     hitCtx.save();
     applyViewTransform(hitCtx);
-    for (let li = layers.length - 1; li >= 0; li--) {
-        const layer = layers[li];
-        if (!layer.visible) continue;
-        hitCtx.lineWidth = layer.thickness / viewScale;
-        hitCtx.lineCap = 'round';
-        hitCtx.lineJoin = 'round';
-        for (let si = layer.segments.length - 1; si >= 0; si--) {
-            const seg = layer.segments[si];
-            if (!seg || seg.points.length < 2) continue;
-
-function hitTestSegment(ix, iy) {
- codex/find-better-mouse-click-detection-method-3x7yw3
-    // Use a cached Path2D and bounding box check for accurate hit testing
-
- codex/find-better-mouse-click-detection-method-sip7ac
-    // Use a cached Path2D and bounding box check for accurate hit testing
-
-    // Use the canvas API to determine if the point lies within a stroked path
- codex/find-better-mouse-click-detection-method-sqdvfk
-
- codex/find-better-mouse-click-detection-method-40nq5x
-
     const tol = 5 / viewScale; // constant screen-space tolerance
- DevSchmeaticHtml
- DevSchmeaticHtml
- DevSchmeaticHtml
- DevSchmeaticHtml
     for (let li = layers.length - 1; li >= 0; li--) {
         const layer = layers[li];
         if (!layer.visible) continue;
         for (let si = layer.segments.length - 1; si >= 0; si--) {
             const seg = layer.segments[si];
             if (!seg || seg.points.length < 2) continue;
- codex/find-better-mouse-click-detection-method-3x7yw3
-
- codex/find-better-mouse-click-detection-method-sip7ac
-DevSchmeaticHtml
-DevSchmeaticHtml
             ensureSegmentPath(seg);
             const half = (layer.thickness / viewScale) / 2;
             const { minX, maxX, minY, maxY } = seg.bbox;
             if (ix < minX - half || ix > maxX + half || iy < minY - half || iy > maxY + half) continue;
- codex/find-better-mouse-click-detection-method-jn7jky
+            // Use the segment's actual thickness so hits only register on the line itself
+            hitCtx.lineWidth = layer.thickness / viewScale + 2 * tol;
+            hitCtx.lineCap = 'round';
+            hitCtx.lineJoin = 'round';
             if (hitCtx.isPointInStroke(seg.path, sx, sy)) {
                 hitCtx.restore();
-
-            hitCtx.lineWidth = layer.thickness / viewScale;
-            hitCtx.lineCap = 'round';
-            hitCtx.lineJoin = 'round';
-            if (hitCtx.isPointInStroke(seg.path, ix, iy)) {
-codex/find-better-mouse-click-detection-method-3x7yw3
-
-
- codex/find-better-mouse-click-detection-method-sqdvfk
-            // Use the segment's actual thickness so hits only register on the line itself
-            hitCtx.lineWidth = layer.thickness / viewScale;
-
- codex/find-better-mouse-click-detection-method-40nq5x
-            // Use the segment's actual thickness so hits only register on the line itself
-            hitCtx.lineWidth = layer.thickness / viewScale;
-
-            hitCtx.lineWidth = layer.thickness / viewScale + 2 * tol;
- DevSchmeaticHtml
- DevSchmeaticHtml
-            hitCtx.lineCap = 'round';
-            hitCtx.lineJoin = 'round';
-            hitCtx.beginPath();
-            hitCtx.moveTo(seg.points[0].x, seg.points[0].y);
-            for (let i = 1; i < seg.points.length; i++) {
-                hitCtx.lineTo(seg.points[i].x, seg.points[i].y);
-            }
-            if (hitCtx.isPointInStroke(ix, iy)) {
- DevSchmeaticHtml
- DevSchmeaticHtml
-DevSchmeaticHtml
                 return { layer: li, index: si };
             }
         }


### PR DESCRIPTION
## Summary
- remove leftover merge markers
- tighten segment hit detection using Path2D and constant tolerance

## Testing
- `node --check docs/js/tools.js`


------
https://chatgpt.com/codex/tasks/task_e_68b24615e38c8325bd992fe5ffbb7675