### PR TITLE
Fix hit testing for line segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1605,11 +1605,6 @@ consoleRun.addEventListener('click',()=> runCommand(consoleIn.value));
 consoleIn.addEventListener('keydown',(e)=>{ if(e.key==='Enter') runCommand(consoleIn.value); });
 clearHistoryBtn.addEventListener('click',()=>{ history=[]; historyList.innerHTML=''; logHistory('History cleared'); });
 
-codex/find-better-mouse-click-detection-method-jn7jky
-
-// codex/find-better-mouse-click-detection-method-3x7yw3
- codex/find-better-mouse-click-detection-method-sip7ac
-
 function hitTestAnnotation(ix,iy){
   for(let i=annotations.length-1;i>=0;i--){
     const a=annotations[i]; const size=Math.max(10, +a.size||18);
@@ -1619,42 +1614,7 @@ function hitTestAnnotation(ix,iy){
   }
   return -1;
 }
-function hitTestSegment(ix,iy){
-  for(let i=segments.length-1;i>=0;i--){
-    const s=segments[i];
-    const L=layers[s.layer];
-    if(!L || !L.visible) continue;
- codex/find-better-mouse-click-detection-method-sqdvfk
-    hitCtx.lineWidth=(s.thick||L.thickness||1)/viewScale;
-    hitCtx.lineCap='round';
-    hitCtx.lineJoin='round';
-    hitCtx.beginPath();
-    hitCtx.moveTo(s.x1,s.y1);
-    hitCtx.lineTo(s.x2,s.y2);
-    if(hitCtx.isPointInStroke(ix,iy)) return i;
-  }
-  return -1;
 
-    const tol=Math.max((s.thick||1)/2,0.5);
-    const d=distPointToSegment(ix,iy,s.x1,s.y1,s.x2,s.y2);
-    if(d<=tol) return i;
-  }
-  return -1;
-}
-function distPointToSegment(px,py,x1,y1,x2,y2){
-  const vx=x2-x1, vy=y2-y1, wx=px-x1, wy=py-y1;
-  const c1 = vx*wx + vy*wy;
-  if(c1<=0) return Math.hypot(px-x1,py-y1);
-  const c2 = vx*vx + vy*vy;
-  if(c2<=c1) return Math.hypot(px-x2,py-y2);
-  const b = c1 / c2;
-  const bx = x1 + b*vx, by = y1 + b*vy;
-  return Math.hypot(px-bx, py-by);
- DevSchmeaticHtml
-}
-
-DevSchmeaticHtml
- DevSchmeaticHtml
 function eraseAt(ix,iy,size){ if(!layers.length) return; clearMask(layers[activeLayer].mask, Math.round(ix), Math.round(iy), Math.max(1, Math.round(size/2))); }
 function eraseLineTo(ix,iy,size){ if(!layers.length) return; if(!lastErase){ lastErase={x:ix,y:iy}; eraseAt(ix,iy,size); return; } const steps=Math.ceil(Math.hypot(ix-lastErase.x, iy-lastErase.y) / 1); for(let t=0;t<=steps;t++){ const x=lerp(lastErase.x,ix,t/steps); const y=lerp(lastErase.y,iy,t/steps); eraseAt(x,y,size); } lastErase={x:ix,y:iy}; }
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -134,7 +134,8 @@ function setupEventListeners() {
             return;
         }
 
-        hit = hitTestSegment(e.offsetX, e.offsetY);
+        const [hx, hy] = screenToImg(e.offsetX, e.offsetY);
+        hit = hitTestSegment(hx, hy);
         if (hit) {
             selectedSeg = hit;
             selectedSym = -1;

--- a/docs/js/tools.js
+++ b/docs/js/tools.js
@@ -72,94 +72,26 @@ function ensureSegmentPath(seg) {
     seg.bbox = { minX, maxX, minY, maxY };
 }
 
- codex/find-better-mouse-click-detection-method-jn7jky
-function hitTestSegment(x, y) {
-    // Accept either screen or image coordinates.
-    // If the point appears to be in image space, convert it.
-    let sx = x, sy = y, ix = x, iy = y;
-    if (x >= 0 && x <= view.width && y >= 0 && y <= view.height) {
-        [ix, iy] = screenToImg(x, y);
-    } else {
-        [sx, sy] = imgToScreen(x, y);
-    }
-
+function hitTestSegment(ix, iy) {
+    const [sx, sy] = imgToScreen(ix, iy);
     hitCtx.save();
     applyViewTransform(hitCtx);
-    for (let li = layers.length - 1; li >= 0; li--) {
-        const layer = layers[li];
-        if (!layer.visible) continue;
-        hitCtx.lineWidth = layer.thickness / viewScale;
-        hitCtx.lineCap = 'round';
-        hitCtx.lineJoin = 'round';
-        for (let si = layer.segments.length - 1; si >= 0; si--) {
-            const seg = layer.segments[si];
-            if (!seg || seg.points.length < 2) continue;
-
-function hitTestSegment(ix, iy) {
- codex/find-better-mouse-click-detection-method-3x7yw3
-    // Use a cached Path2D and bounding box check for accurate hit testing
-
- codex/find-better-mouse-click-detection-method-sip7ac
-    // Use a cached Path2D and bounding box check for accurate hit testing
-
-    // Use the canvas API to determine if the point lies within a stroked path
- codex/find-better-mouse-click-detection-method-sqdvfk
-
- codex/find-better-mouse-click-detection-method-40nq5x
-
     const tol = 5 / viewScale; // constant screen-space tolerance
- DevSchmeaticHtml
- DevSchmeaticHtml
- DevSchmeaticHtml
- DevSchmeaticHtml
     for (let li = layers.length - 1; li >= 0; li--) {
         const layer = layers[li];
         if (!layer.visible) continue;
         for (let si = layer.segments.length - 1; si >= 0; si--) {
             const seg = layer.segments[si];
             if (!seg || seg.points.length < 2) continue;
- codex/find-better-mouse-click-detection-method-3x7yw3
-
- codex/find-better-mouse-click-detection-method-sip7ac
-DevSchmeaticHtml
-DevSchmeaticHtml
             ensureSegmentPath(seg);
-            const half = (layer.thickness / viewScale) / 2;
+            const half = (layer.thickness / viewScale) / 2 + tol;
             const { minX, maxX, minY, maxY } = seg.bbox;
             if (ix < minX - half || ix > maxX + half || iy < minY - half || iy > maxY + half) continue;
- codex/find-better-mouse-click-detection-method-jn7jky
+            hitCtx.lineWidth = layer.thickness / viewScale + 2 * tol;
+            hitCtx.lineCap = 'round';
+            hitCtx.lineJoin = 'round';
             if (hitCtx.isPointInStroke(seg.path, sx, sy)) {
                 hitCtx.restore();
-
-            hitCtx.lineWidth = layer.thickness / viewScale;
-            hitCtx.lineCap = 'round';
-            hitCtx.lineJoin = 'round';
-            if (hitCtx.isPointInStroke(seg.path, ix, iy)) {
-codex/find-better-mouse-click-detection-method-3x7yw3
-
-
- codex/find-better-mouse-click-detection-method-sqdvfk
-            // Use the segment's actual thickness so hits only register on the line itself
-            hitCtx.lineWidth = layer.thickness / viewScale;
-
- codex/find-better-mouse-click-detection-method-40nq5x
-            // Use the segment's actual thickness so hits only register on the line itself
-            hitCtx.lineWidth = layer.thickness / viewScale;
-
-            hitCtx.lineWidth = layer.thickness / viewScale + 2 * tol;
- DevSchmeaticHtml
- DevSchmeaticHtml
-            hitCtx.lineCap = 'round';
-            hitCtx.lineJoin = 'round';
-            hitCtx.beginPath();
-            hitCtx.moveTo(seg.points[0].x, seg.points[0].y);
-            for (let i = 1; i < seg.points.length; i++) {
-                hitCtx.lineTo(seg.points[i].x, seg.points[i].y);
-            }
-            if (hitCtx.isPointInStroke(ix, iy)) {
- DevSchmeaticHtml
- DevSchmeaticHtml
-DevSchmeaticHtml
                 return { layer: li, index: si };
             }
         }

--- a/test/hitTestSegment.test.js
+++ b/test/hitTestSegment.test.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+class MockPath2D {
+  constructor(){ this.points = []; }
+  moveTo(x, y){ this.points.push({x, y}); }
+  lineTo(x, y){ this.points.push({x, y}); }
+}
+
+class MockContext {
+  constructor(){ this.lineWidth = 1; }
+  save(){}
+  restore(){}
+  lineCap = 'butt';
+  lineJoin = 'miter';
+  isPointInStroke(path, x, y){
+    for(let i=0;i<path.points.length-1;i++){
+      const p1 = path.points[i];
+      const p2 = path.points[i+1];
+      const dx = p2.x - p1.x;
+      const dy = p2.y - p1.y;
+      const len2 = dx*dx + dy*dy;
+      let t = ((x - p1.x)*dx + (y - p1.y)*dy) / (len2||1);
+      t = Math.max(0, Math.min(1, t));
+      const px = p1.x + t*dx;
+      const py = p1.y + t*dy;
+      const dist = Math.hypot(x - px, y - py);
+      if(dist <= this.lineWidth/2) return true;
+    }
+    return false;
+  }
+}
+
+global.Path2D = MockPath2D;
+global.OffscreenCanvas = class{ getContext(){ return new MockContext(); } };
+function createElement(){
+  return {
+    getContext: () => new MockContext(),
+    style: {},
+    appendChild(){},
+  };
+}
+global.document = {
+  createElement,
+  getElementById: () => null,
+  body: { appendChild(){} }
+};
+global.window = global;
+global.applyViewTransform = () => {};
+
+const code = fs.readFileSync(path.join(__dirname, '../docs/js/tools.js'), 'utf8');
+vm.runInThisContext(code);
+
+global.viewScale = 1;
+global.panX = 0;
+global.panY = 0;
+global.imgW = 0;
+global.imgH = 0;
+global.view = { width:200, height:200, getBoundingClientRect: () => ({ left:0, top:0 }) };
+global.layers = [
+  { visible:true, thickness:2, segments:[{ points:[{x:0,y:0},{x:100,y:0}] }] }
+];
+global.symbols = [];
+global.annotations = [];
+global.config = { snapToGrid:false, gridSize:10 };
+
+let hit = hitTestSegment(50,0);
+assert.deepStrictEqual(hit, { layer:0, index:0 });
+
+hit = hitTestSegment(150,50);
+assert.strictEqual(hit, null);
+
+console.log('hitTestSegment tests passed');


### PR DESCRIPTION
## Summary
- standardize `hitTestSegment` to image-space coordinates and expand bounding-box checks
- convert mouse locations to image space before hit testing
- strip broken inline segment tester from `index.html` and add a headless unit test

## Testing
- `node --check docs/js/tools.js`
- `node --check docs/js/main.js`
- `node test/hitTestSegment.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b24615e38c8325bd992fe5ffbb7675